### PR TITLE
Adds media query to handle overflowing content

### DIFF
--- a/styles/index.sass
+++ b/styles/index.sass
@@ -76,6 +76,11 @@
       padding: 3rem
       transform: translate(-50%, -50%)
 
+      @media (max-width: 720px)
+        max-width: initial
+        width: auto
+        min-width: 100%
+
     h1
       font-size: 3rem
       margin: 1rem


### PR DESCRIPTION
Adding this media query, the width of `.slide-content` will be according to its children's width and can therefore be scaled properly.

Closes #61
